### PR TITLE
ci: skip unrelated product jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,9 @@ updates:
         versions: [">= 10"]
       - dependency-name: "typescript"
         versions: [">= 7"]
+      - dependency-name: "@types/node"
+        # Keep type definitions aligned with the Node 24 runtime used by CI/Vercel.
+        versions: [">= 25"]
 
   # Actions used by ci.yml / release.yml / soak-test.yml.
   - package-ecosystem: "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,60 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decide which product surface changed so site-only PRs do not spend a Windows
+  # runner rebuilding the desktop app (and vice versa). Workflow edits run both.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+      site: ${{ steps.filter.outputs.site }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: filter
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          elif git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            files="$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA")"
+          else
+            files=".github/workflows/ci.yml"
+          fi
+
+          app=false
+          site=false
+          while IFS= read -r file; do
+            case "$file" in
+              DigitalWellbeing.sln|digital-wellbeing-app/*|UITests/*|FixtureSeeder/*|.github/workflows/ci.yml)
+                app=true
+                ;;
+            esac
+            case "$file" in
+              pulse/*|.github/workflows/ci.yml)
+                site=true
+                ;;
+            esac
+          done <<< "$files"
+
+          echo "app=$app" >> "$GITHUB_OUTPUT"
+          echo "site=$site" >> "$GITHUB_OUTPUT"
+
   # --------------------------------------------------------------------------
   # WPF app: build + unit tests (Windows-only, WPF / net9.0-windows).
   # --------------------------------------------------------------------------
   app:
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -44,6 +94,8 @@ jobs:
   # Marketing site (pulse/, Next.js). Cross-platform, so Ubuntu is fine.
   # --------------------------------------------------------------------------
   site:
+    needs: changes
+    if: needs.changes.outputs.site == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,31 +12,71 @@ permissions:
   contents: read
 
 jobs:
-  analyze:
-    name: Analyze (${{ matrix.language }})
-    # C# needs the .NET SDK + a real build (manual build-mode); JS/TS is scanned directly from
-    # source (build-mode: none) and doesn't need a Windows runner.
-    runs-on: ${{ matrix.language == 'csharp' && 'windows-latest' || 'ubuntu-latest' }}
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      csharp: ${{ steps.filter.outputs.csharp }}
+      javascript: ${{ steps.filter.outputs.javascript }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: filter
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "schedule" ]]; then
+            csharp=true
+            javascript=true
+          else
+            if [[ "$EVENT_NAME" == "pull_request" ]]; then
+              files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+            elif git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+              files="$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA")"
+            else
+              files=".github/workflows/codeql.yml"
+            fi
+
+            csharp=false
+            javascript=false
+            while IFS= read -r file; do
+              case "$file" in
+                DigitalWellbeing.sln|digital-wellbeing-app/*|UITests/*|FixtureSeeder/*|.github/workflows/codeql.yml)
+                  csharp=true
+                  ;;
+              esac
+              case "$file" in
+                pulse/*|.github/workflows/codeql.yml)
+                  javascript=true
+                  ;;
+              esac
+            done <<< "$files"
+          fi
+
+          echo "csharp=$csharp" >> "$GITHUB_OUTPUT"
+          echo "javascript=$javascript" >> "$GITHUB_OUTPUT"
+
+  analyze-csharp:
+    name: Analyze (csharp)
+    needs: changes
+    if: needs.changes.outputs.csharp == 'true'
+    runs-on: windows-latest
     permissions:
       actions: read
       contents: read
       security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: csharp
-            build-mode: manual
-          - language: javascript-typescript
-            build-mode: none
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
 
       - name: Setup .NET 9.0
-        if: matrix.language == 'csharp'
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '9.0.x'
@@ -44,11 +84,10 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
+          languages: csharp
+          build-mode: manual
 
-      - name: Build (C# only - manual build mode)
-        if: matrix.build-mode == 'manual'
+      - name: Build
         run: |
           dotnet restore DigitalWellbeing.sln
           dotnet build DigitalWellbeing.sln -c Release --no-restore
@@ -56,4 +95,28 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:${{ matrix.language }}"
+          category: /language:csharp
+
+  analyze-javascript:
+    name: Analyze (javascript-typescript)
+    needs: changes
+    if: needs.changes.outputs.javascript == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:javascript-typescript


### PR DESCRIPTION
## What changed
- classify changed files once at the start of CI and CodeQL
- run Windows app CI and C# CodeQL only for app/workflow changes
- run site CI and JavaScript CodeQL only for website/workflow changes
- keep scheduled CodeQL scans comprehensive across both languages
- hold `@types/node` on the Node 24 runtime major

## Why
Website-only Dependabot PRs were unnecessarily allocating Windows runners, rebuilding the WPF application, and running C# CodeQL. This keeps the same relevant coverage while eliminating unrelated jobs. There are no branch-protection rules that depend on skipped job names.

## Validation
- workflow and Dependabot YAML parsed successfully
- diff and secret-pattern checks passed
- PR intentionally changes both workflow files, so GitHub will exercise all app/site and C#/JavaScript paths on this PR